### PR TITLE
Added furniture detection failure as exception clause.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,11 @@ yolo_test.py
 clip_test.py
 test_process.py
 clip_embedding_data/*
+test_yolo.py
 
 /models/
 *.onnx
 *.npz
 image/
+
+*.jpg

--- a/main.py
+++ b/main.py
@@ -54,12 +54,12 @@ async def process_image(file: UploadFile = File(None), url: str = Form(None)):
             )
         print(len(clip_emb), "차원 CLIP 임베딩 벡터 생성 완료")
         return JSONResponse(content=results)
-    except Exception:
+    except Exception as e:
         import traceback
 
         print(traceback.format_exc())
         return JSONResponse(
-            status_code=500, content={"detail": "Failed to process image"}
+            status_code=500, content={"detail": "Failed to process image", "cause": f"{str(e)}"}
         )
 
 


### PR DESCRIPTION
1. Changes:
-> Refactored `yolo_fun.py` to throw `NoResultsFoundException`
-> Added `"cause": f"{str(e)}"` with the exception message to the 500 response. 
-> added test and .jpg files to the gitignore 
2. Tested ✅ 
with 
![error_image](https://github.com/user-attachments/assets/01409648-ec63-46ff-ad6f-aabcdc73f621)
response:
```
{
  "detail": "Failed to process image",
  "cause": "Unable to detect furniture objects."
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses for image processing by including detailed exception information in API responses.
  * Enhanced detection result handling to explicitly signal when no objects are found.

* **Chores**
  * Updated the ignore list to exclude test scripts and JPEG image files from version control.
  * Improved formatting consistency in configuration files.

* **New Features**
  * Introduced clearer error messaging when no detection results are found, providing users with more informative feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->